### PR TITLE
RMMIS-5107 - Update ValueChangeMixin to send all field props with value change event OR passed in event. This way, we can send custom props to the event handlers downstream in transparent way.

### DIFF
--- a/src/ValueChangeMixin.js
+++ b/src/ValueChangeMixin.js
@@ -1,6 +1,7 @@
 var React = require('react');
 var Flux = require('fluxify');
 var constants = require('./constants');
+var Immutable = require('immutable');
 var _ = require('lodash');
 
 /**
@@ -19,19 +20,20 @@ module.exports = {
   onChange: function(event){
     var actionName = this.props.fieldValueChangeAction || event.actionName || constants.actions.FIELD_VALUE_CHANGE;
     var state = event.stateChange || {value: event.target.value};
-    var payload = _.pick(this.props, ['id', 'name', 'rules', 'type','maxLength','required','persistInSession', 'disabled']);
-    payload.visible = this.state.visible;
-    if(this.props.mask) {
-      payload.value = state.value;
-      payload.unmasked = state.unmasked;
-    } else {
-      payload.value = event.target.value;
-      if(event.target.dateString) {
-        payload.dateString = event.target.dateString;
+    var payload = Immutable.fromJS(this.props).withMutations((mutablePayload) => {
+      mutablePayload.set('visible', this.state.visible);
+      if (this.props.mask) {
+        mutablePayload.set('value',state.value);
+        mutablePayload.set('unmasked', state.unmasked);
+      } else {
+        mutablePayload.set('value',event.target.value);
+        if (event.target.dateString) {
+          mutablePayload.set('dateString',event.target.dateString);
+        }
       }
-    }
+    });
     this.setState(state);
-    Flux.doAction(actionName, payload);
+    Flux.doAction(actionName, payload.toJSON());
   },
 
   /**

--- a/test/unit/value-change-mixin-spec.js
+++ b/test/unit/value-change-mixin-spec.js
@@ -13,7 +13,8 @@ describe('ValueChangeMixin', function() {
       name: 'testText',
       label: 'Test',
       type: 'text',
-      value: ''
+      value: '',
+      customPropType: 'CustomType'
     };
     var dom = TestUtils.renderIntoDocument(<Field {...textFieldConfig}/>);
     var wrapperDiv = dom.getDOMNode();
@@ -27,6 +28,7 @@ describe('ValueChangeMixin', function() {
         expect(data.name).toEqual(textFieldConfig.name);
         expect(data.type).toEqual(textFieldConfig.type);
         expect(data.value).toEqual('value test');
+        expect(data.customPropType).toEqual(textFieldConfig.customPropType);
         done();
       }
     });


### PR DESCRIPTION
Update ValueChangeMixin to send all field props with value change event OR passed in event. This way, we can send custom props to the event handlers downstream in transparent way.