### PR TITLE
RMMIS-5755: File Input Styling

### DIFF
--- a/src/styles/Form.less
+++ b/src/styles/Form.less
@@ -21,5 +21,3 @@ fieldset {
     font-size: @label-size;
   }
 }
-
-input[type="file"] { padding: 0; }


### PR DESCRIPTION
RMMIS-5755: The problem I originally made this change for was actually just the result of using the 'form-control' class. Since Bootstrap doesn't support it as different browsers handle file input styling differently and cause strange visual effects when the standard border is applied, I am simply backing it out.