### PR TITLE
RMMIS-6065-fix-masking-rules-issue

### DIFF
--- a/src/ValueChangeMixin.js
+++ b/src/ValueChangeMixin.js
@@ -28,9 +28,7 @@ export default {
         .set('visible', this.state.visible)
         .set('disabled', this.state.disabled);
       if (this.props.mask) {
-        mutablePayload
-          .set('value', state.value)
-          .set('unmasked', state.unmasked);
+        mutablePayload.set('value', state.unmasked);
       } else {
         mutablePayload.set('value', event.target.value);
         if (event.target.dateString) {

--- a/src/ValueChangeMixin.js
+++ b/src/ValueChangeMixin.js
@@ -28,7 +28,9 @@ export default {
         .set('visible', this.state.visible)
         .set('disabled', this.state.disabled);
       if (this.props.mask) {
-        mutablePayload.set('value', state.unmasked);
+        mutablePayload
+          .set('value', state.unmasked)
+          .set('masked', state.value);
       } else {
         mutablePayload.set('value', event.target.value);
         if (event.target.dateString) {

--- a/test/unit/input-spec.js
+++ b/test/unit/input-spec.js
@@ -50,10 +50,10 @@ describe('Input', function(){
     Dispatcher.register( 'test-ssn-change' , function(action, data){
       if( action === constants.actions.FIELD_VALUE_CHANGE &&
           data.id === 'test-ssn') {
-        if(data.unmasked === '012345678') {
+        if(data.value === '012345678') {
           Dispatcher.unregister('test-ssn-change');
-          expect(data.value).toEqual('***-**-5678');
-          expect(data.unmasked).toEqual('012345678');
+          expect(data.masked).toEqual('***-**-5678');
+          expect(data.value).toEqual('012345678');
           done();
         } else {
           numCount++;
@@ -79,8 +79,8 @@ describe('Input', function(){
       if( action === constants.actions.FIELD_VALUE_CHANGE &&
           data.id === 'test-date') {
         Dispatcher.unregister('test-date-change');
-        expect(data.value).toEqual('**/**/1979');
-        expect(data.unmasked).toEqual(date);
+        expect(data.masked).toEqual('**/**/1979');
+        expect(data.value).toEqual(date);
         done();
       }
     });
@@ -102,8 +102,8 @@ describe('Input', function(){
       if( action === constants.actions.FIELD_VALUE_CHANGE &&
           data.id === 'test-cc') {
         Dispatcher.unregister('test-cc-change');
-        expect(data.value).toEqual('$$$$ $$$$ $$$$ 0101');
-        expect(data.unmasked).toEqual(ccNum);
+        expect(data.masked).toEqual('$$$$ $$$$ $$$$ 0101');
+        expect(data.value).toEqual(ccNum);
         done();
       }
     });


### PR DESCRIPTION
RMMIS-6065: Fix rules errors on masked FVC's by sending only the unmasked value