### PR TITLE
RMMIS-6065-fix-masking-rules-onblur

### DIFF
--- a/src/ValueChangeMixin.js
+++ b/src/ValueChangeMixin.js
@@ -50,7 +50,15 @@ export default {
    * @fires FIELD_BLUR
    */
   onBlur(event) {
-    let payload = _.extend({value: this.state.value}, this.props);
-    Dispatcher.dispatch(FIELD_BLUR, payload);
+    let payload = Immutable.fromJS(this.props).withMutations((mutablePayload) => {
+      if (this.props.mask) {
+        mutablePayload
+          .set('value', this.state.unmasked)
+          .set('masked', this.state.value);
+      } else {
+        mutablePayload.set('value', this.state.value);
+      }
+    });
+    Dispatcher.dispatch(FIELD_BLUR, payload.toJSON());
   }
 };


### PR DESCRIPTION
RMMIS-6065: Made onBlur payload immutable and switched to only send the unmasked value for its' validation as well.