### PR TITLE
RMMIS-6338-support-persisting-single-checkbox-values

### DIFF
--- a/src/ValueChangeMixin.js
+++ b/src/ValueChangeMixin.js
@@ -32,7 +32,8 @@ export default {
           .set('value', state.unmasked)
           .set('masked', state.value);
       } else {
-        mutablePayload.set('value', event.target.value);
+        let value = _.isEqual(this.props.type, 'checkbox') && !this.props.isFieldGroup ? state.checked : event.target.value;
+        mutablePayload.set('value', value);
         if (event.target.dateString) {
           mutablePayload.set('dateString', event.target.dateString);
         }

--- a/test/fixtures/field-checkbox.json
+++ b/test/fixtures/field-checkbox.json
@@ -2,18 +2,5 @@
   "id" : "test-checkbox",
   "type" : "checkbox",
   "name" : "test-checkbox",
-  "label" : "Test Checkbox",
-  "required" : false,
-  "options" : {
-    "items" : [
-      {
-        "label" : "Checkbox 1",
-        "value" : "1"
-      },
-      {
-        "label" : "Checkbox 2",
-        "value" : "2"
-      }
-    ]
-  }
+  "label" : "Test Checkbox"
 }

--- a/test/unit/checkable-spec.js
+++ b/test/unit/checkable-spec.js
@@ -1,18 +1,24 @@
-var React = require('react');
-var fixture = require('../fixtures/radio.json');
-var Checkable = require('../../src/Checkable');
-var TestUtils = require('react/lib/ReactTestUtils');
-var update = require('react/lib/update');
-var Dispatcher = require('fluxify').dispatcher;
-var constants = require('../../src/constants');
+import React from 'react';
+import fixture from '../fixtures/radio.json';
+import checkboxFixture from '../fixtures/field-checkbox.json';
+import Checkable from '../../src/Checkable';
+import TestUtils from 'react/lib/ReactTestUtils';
+import update from 'react/lib/update';
+import {dispatcher as Dispatcher} from 'fluxify';
+import constants from '../../src/constants';
 
-describe('Checkable', function(){
+let {
+  FIELD_VALUE_CHANGE,
+  FIELD_GROUP_VALUE_CHANGE
+} = constants.actions;
 
-  it('can render a single radio input', function(){
-    var dom = TestUtils.renderIntoDocument(<Checkable {...fixture.config}/>);
-    var wrapperDiv = dom.getDOMNode();
-    var label = wrapperDiv.childNodes[0];
-    var input = label.childNodes[0];
+describe('Checkable', () => {
+
+  it('can render a single radio input', () => {
+    let dom = TestUtils.renderIntoDocument(<Checkable {...fixture.config}/>);
+    let wrapperDiv = dom.getDOMNode();
+    let label = wrapperDiv.childNodes[0];
+    let input = label.childNodes[0];
     expect(wrapperDiv.className).toEqual('radio-inline');
     expect(label.getAttribute('for')).toEqual(fixture.config.id);
     expect(input.type).toEqual(fixture.config.type);
@@ -21,67 +27,85 @@ describe('Checkable', function(){
     expect(input.checked).toBe(false);
   });
 
-  it('can render a required radio input', function(){
-    var config = update(fixture.config, {required: {$set: true}});
-    var dom = TestUtils.renderIntoDocument(<Checkable {...config}/>);
-    var label = dom.getDOMNode().childNodes[0];
+  it('can render a single checkbox input and return boolean FIELD_VALUE_CHANGE values upon checking', (done) => {
+    Dispatcher.register('CHECKABLE-TEST-0', (action, data) => {
+      if (action === FIELD_VALUE_CHANGE && data.id === checkboxFixture.id) {
+        Dispatcher.unregister('CHECKABLE-TEST-0');
+        expect(data.value).toBe(true);
+        done();
+      }
+    });
+
+    let dom = TestUtils.renderIntoDocument(<Checkable {...checkboxFixture}/>);
+    let wrapperDiv = dom.getDOMNode();
+    let label = wrapperDiv.childNodes[0];
+    let input = label.childNodes[0];
+    expect(wrapperDiv.className).toEqual('checkbox-inline');
+    expect(label.getAttribute('for')).toEqual(checkboxFixture.id);
+    expect(input.type).toEqual(checkboxFixture.type);
+    expect(input.name).toEqual(checkboxFixture.name);
+    input.checked = true;
+    TestUtils.Simulate.change(input);
+  });
+
+  it('can render a required radio input', () => {
+    let config = update(fixture.config, {required: {$set: true}});
+    let dom = TestUtils.renderIntoDocument(<Checkable {...config}/>);
+    let label = dom.getDOMNode().childNodes[0];
     expect(label.childNodes[1].textContent).toEqual(fixture.config.label);
     expect(label.childNodes[2].textContent).toEqual('*');
   });
 
-  it('can render a checked radio input', function(){
-    var config = update(fixture.config, {checked: {$set: true}});
-    var dom = TestUtils.renderIntoDocument(<Checkable {...config}/>);
-    var input = dom.getDOMNode().childNodes[0].childNodes[0];
+  it('can render a checked radio input', () => {
+    let config = update(fixture.config, {checked: {$set: true}});
+    let dom = TestUtils.renderIntoDocument(<Checkable {...config}/>);
+    let input = dom.getDOMNode().childNodes[0].childNodes[0];
     expect(input.checked).toBe(true);
   });
 
-  it('can publish a radio input value on change', function(done){
-    Dispatcher.register( 'CHECKABLE-TEST-1', function(action,data){
-      if( action === constants.actions.FIELD_VALUE_CHANGE &&
-          data.id === fixture.config.id) {
-          expect(data.id).toEqual(fixture.config.id);
-          expect(data.name).toEqual(fixture.config.name);
-          expect(data.value).toBe(fixture.config.value);
-          Dispatcher.unregister( 'CHECKABLE-TEST-1' );
-          done();
+  it('can publish a radio input value on change', (done) => {
+    Dispatcher.register('CHECKABLE-TEST-1', (action, data) => {
+      if (action === FIELD_VALUE_CHANGE && data.id === fixture.config.id) {
+        Dispatcher.unregister('CHECKABLE-TEST-1');
+        expect(data.id).toEqual(fixture.config.id);
+        expect(data.name).toEqual(fixture.config.name);
+        expect(data.value).toBe(fixture.config.value);
+        done();
       }
-    }.bind(this));
-    var comp = TestUtils.renderIntoDocument(<Checkable {...fixture.config}/>);
-    var radio = comp.getDOMNode().childNodes[0].childNodes[0];
+    });
+    let comp = TestUtils.renderIntoDocument(<Checkable {...fixture.config}/>);
+    let radio = comp.getDOMNode().childNodes[0].childNodes[0];
     TestUtils.Simulate.change(radio, {target: {checked: true}});
   });
 
-  it('will publish a value of "null" if input is not checked', function(done){
-    Dispatcher.register( 'CHECKABLE-TEST-2', function(action,data){
-      if( action === constants.actions.FIELD_VALUE_CHANGE &&
-          data.id === fixture.config.id) {
-          expect(data.id).toEqual(fixture.config.id);
-          expect(data.name).toEqual(fixture.config.name);
-          expect(data.value).toBe(null);
-          Dispatcher.unregister( 'CHECKABLE-TEST-2' );
-          done();
+  it('will publish a value of "null" if input is not checked', (done) => {
+    Dispatcher.register('CHECKABLE-TEST-2', (action, data) => {
+      if (action === FIELD_VALUE_CHANGE && data.id === fixture.config.id) {
+        Dispatcher.unregister('CHECKABLE-TEST-2');
+        expect(data.id).toEqual(fixture.config.id);
+        expect(data.name).toEqual(fixture.config.name);
+        expect(data.value).toBe(null);
+        done();
       }
-    }.bind(this));
-    var comp = TestUtils.renderIntoDocument(<Checkable {...fixture.config}/>);
-    var radio = comp.getDOMNode().childNodes[0].childNodes[0];
+    });
+    let comp = TestUtils.renderIntoDocument(<Checkable {...fixture.config}/>);
+    let radio = comp.getDOMNode().childNodes[0].childNodes[0];
     TestUtils.Simulate.change(radio, {target: {checked: false}});
   });
 
-  it('will publish a "fieldGroup:item:change" event if input is part of a group', function(done){
-    Dispatcher.register( 'CHECKABLE-TEST-3', function(action,data){
-      if( action === constants.actions.FIELD_GROUP_VALUE_CHANGE &&
-          data.id === fixture.config.id) {
-          expect(data.id).toEqual(fixture.config.id);
-          expect(data.name).toEqual(fixture.config.name);
-          expect(data.value).toBe(null);
-          Dispatcher.unregister( 'CHECKABLE-TEST-3' );
-          done();
+  it('will publish a "fieldGroup:item:change" event if input is part of a group', (done) => {
+    Dispatcher.register('CHECKABLE-TEST-3', (action, data) => {
+      if (action === FIELD_GROUP_VALUE_CHANGE && data.id === fixture.config.id) {
+        Dispatcher.unregister('CHECKABLE-TEST-3');
+        expect(data.id).toEqual(fixture.config.id);
+        expect(data.name).toEqual(fixture.config.name);
+        expect(data.value).toBe(null);
+        done();
       }
-    }.bind(this));
-    var config = update(fixture.config, {isFieldGroup: {$set: true}, 'parent':{$set : 'parent123'}});
-    var comp = TestUtils.renderIntoDocument(<Checkable {...config}/>);
-    var radio = comp.getDOMNode().childNodes[0].childNodes[0];
+    });
+    let config = update(fixture.config, {isFieldGroup: {$set: true}, parent: {$set: 'parent123'}});
+    let comp = TestUtils.renderIntoDocument(<Checkable {...config}/>);
+    let radio = comp.getDOMNode().childNodes[0].childNodes[0];
     TestUtils.Simulate.change(radio, {target: {checked: false}});
   });
 


### PR DESCRIPTION
RMMIS-6338: Add support for persisting values from single checkboxes (i.e. not in a field-group)