### PR TITLE
RMMIS-6177-file-upload-api-support

### DIFF
--- a/src/FileListItem.jsx
+++ b/src/FileListItem.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import constants from './constants';
 import Action from './Action';
 
-let {FILE_UPLOAD_PREVIEW_REMOVE} = constants.actions;
+let {FILE_PREVIEW_LIST_REMOVE} = constants.actions;
 
 /**
 * Renders file preview list items for the File component.
@@ -13,6 +13,7 @@ class FileListItem extends React.Component {
 
   render() {
     let file = this.props.file;
+    let eventAction = this.props.readOnly ? '' : FILE_PREVIEW_LIST_REMOVE;
     return (
       <li className="file-preview-list-item row mblg">
         <div className="col-md-6">
@@ -22,9 +23,10 @@ class FileListItem extends React.Component {
             type="link"
             name="remove"
             className="text-left"
+            fileId={file.id}
             removalId={this.props.fileIdx}
             dataParent={this.props.dataParent}
-            event={FILE_UPLOAD_PREVIEW_REMOVE} />
+            event={eventAction} />
         </div>
         <div className="col-md-6">
           <img

--- a/src/constants.js
+++ b/src/constants.js
@@ -40,8 +40,9 @@ module.exports = {
     "ENTRYLIST_ENTRY_REMOVE": "removeEntryListEntry",
     "ENTRYLIST_NEW_ENTRY_ADD": "addNewEntryListEntry",
     "ENTRYLIST_FIELD_VALUE_CHANGE": "entryListFieldValueChange",
-    "FILE_UPLOAD_PREVIEW_REMOVE": "removeFileUploadPreview",
     "FILE_PREVIEW_LIST_GET": "getFilePreviewList",
-    "FILE_PREVIEW_LIST_LOAD": "loadFilePreviewList"
+    "FILE_PREVIEW_LIST_LOAD": "loadFilePreviewList",
+    "FILE_PREVIEW_LIST_SEND": "sendFilePreviewList",
+    "FILE_PREVIEW_LIST_REMOVE": "removeFilePreviewList"
   }
 };


### PR DESCRIPTION
RMMIS-6177 - Changes to the File component in accordance with the latest File Upload API stuff, also added a readOnly prop for disallowing CRUD or FVC for scenarios like Review & Submit, wrote tests for all above